### PR TITLE
Use the SECRET_KEY from the environment variable

### DIFF
--- a/images/ansible-tower/docker-assets/entrypoint
+++ b/images/ansible-tower/docker-assets/entrypoint
@@ -3,6 +3,9 @@
 # dump docker container run variable into a file for systemd to load
 env > /container.env.vars
 
+echo "== Writing SECRET_KEY =="
+echo ${ANSIBLE_SECRET_KEY} > /etc/tower/SECRET_KEY
+
 # Wait for postgres to be up
 echo "== Checking ${DATABASE_SERVICE_NAME}:5432 status =="
 


### PR DESCRIPTION
The /etc/tower/SECRET_KEY is used as the ansible tower encryption key
for sensitive information stored in the database.

This key is also installed when the rpm is installed (which is to
say, into the image). In order for the key not to be the same across
all images we expect it to be specified as an environment variable
at run time.

We are providing this in the manageiq-pods repo [here](https://github.com/ManageIQ/manageiq-pods/blob/5e8ca5aa8ff3ad8267c55a660ed7b3bc47e56d5d/templates/miq-template.yaml#L575) 