### PR TITLE
Add /sys/fs/cgroup as a volume in the docker image

### DIFF
--- a/images/ansible-tower/Dockerfile
+++ b/images/ansible-tower/Dockerfile
@@ -56,5 +56,7 @@ COPY docker-assets/initialize-tower.service /usr/lib/systemd/system
 
 RUN systemctl enable initialize-tower
 
+VOLUME /sys/fs/cgroup
+
 ENTRYPOINT ["entrypoint"]
 CMD [ "/usr/sbin/init" ]


### PR DESCRIPTION
Without this we fail to start rabbitmq-server with the following output:

rabbitmq-server[3169]: systemd unit for activation check: "-.slice"
rabbitmq-server[3169]: Unexpected status from systemd "systemctl: invalid option -- '.'\n"
rabbitmq-server[3169]: systemd READY notification failed, beware of timeouts

https://bugzilla.redhat.com/show_bug.cgi?id=1516829

See also: https://github.com/rabbitmq/rabbitmq-server/issues/1187